### PR TITLE
Chore - remove deprecated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "author": "just4fun <houritsunohikari@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "react-native-iphone-x-helper": "^1.2.0"
+    "rn-iphone-helper": "^1.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,7 @@ import {
   StyleSheet,
   LayoutAnimation
 } from 'react-native';
-import { isIphoneX, getBottomSpace } from 'react-native-iphone-x-helper';
-
+import { isIphoneX, getBottomSpace } from 'rn-iphone-helper'
 export default class KeyboardAccessory extends Component {
   static defaultProps = {
     backgroundColor: '#f6f6f6',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,7 @@
 # yarn lockfile v1
 
 
-react-native-iphone-x-helper@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.0.tgz#9f8a376eb00bc712115abff4420318a0063fa796"
+rn-iphone-helper@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rn-iphone-helper/-/rn-iphone-helper-1.0.0.tgz#a8dd288db05ff5195a1675d2cf53566072f56815"
+  integrity sha512-pd1KxAlY2/GrUC2djAU2n8bE49nWljpq053CgJrsrj+3aRVioIpWSzgoWeS4g4sm+gNWSWZXjCmdUMTwyb1DIw==


### PR DESCRIPTION
### Summary
Update library with new and updated dependencies.

### Tasks completed
- [x] remove deprecated [`react-native-iphone-x-helper`](https://github.com/ptelad/react-native-iphone-x-helper) package
- [x] add up to date drop in replacement [`rn-iphone-helper`](https://www.npmjs.com/package/rn-iphone-helper) package

Related Issues

There is an extra bit of space between the keyboard and the sticker accessory (as can be seen below) on iPhone 14 Pro models due to lack of support for iPhone 14 on the old [`react-native-iphone-x-helper`](https://github.com/ptelad/react-native-iphone-x-helper)  library, and PR is mean to fix itl

#5 

![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-13 at 20 01 57](https://user-images.githubusercontent.com/32770340/201541133-5d948929-538b-4e37-9f71-b48eec4a7965.png)

